### PR TITLE
setup zustand user/session strore

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,15 +1,26 @@
 "use client";
 
 import Link from "next/link";
-import {authClient, useSession} from "@/lib/auth-client";
-import {Button} from "@/components/ui/button";
-import {Card, CardContent, CardHeader, CardTitle} from "@/components/ui/card";
+import { useSession, authClient } from "@/lib/auth-client";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+import { useAuthStore } from "@/lib/stores/auth-store";
 
 export default function Dashboard() {
-    const {data: session, isPending} = useSession();
-
+    const { data: session, isPending } = useSession();
     const router = useRouter();
+    const { authData, setAuthData, clearAuthData } = useAuthStore();
+
+    // Synchroniser la session Better Auth avec le store
+    useEffect(() => {
+        if (session) {
+            setAuthData(session);
+        } else {
+            clearAuthData();
+        }
+    }, [session, setAuthData, clearAuthData]);
 
     if (isPending) {
         return <div>Chargement...</div>;
@@ -37,7 +48,9 @@ export default function Dashboard() {
         <div className="flex items-center justify-center min-h-screen">
             <Card className="max-w-md">
                 <CardHeader>
-                    <CardTitle>Bienvenue, {session.user.name || session.user.email}</CardTitle>
+                    <CardTitle>
+                        Bienvenue, {authData?.user.name || authData?.user.email || "Utilisateur"}
+                    </CardTitle>
                 </CardHeader>
                 <CardContent>
                     <p>Vous êtes connecté !</p>
@@ -45,6 +58,7 @@ export default function Dashboard() {
                         onClick={async () => {
                             try {
                                 await authClient.signOut();
+                                clearAuthData();
                                 router.push("/");
                             } catch (error) {
                                 console.error("Erreur lors de la déconnexion:", error);

--- a/src/lib/stores/auth-store.ts
+++ b/src/lib/stores/auth-store.ts
@@ -1,0 +1,40 @@
+import { create } from "zustand";
+
+// Type aligné avec useSession
+interface AuthUser {
+    id: string;
+    name: string;
+    email: string;
+    emailVerified: boolean;
+    image?: string | null | undefined;
+    createdAt: Date | string;
+    updatedAt: Date | string;
+}
+
+interface AuthSession {
+    id: string;
+    expiresAt: string | Date;
+    token: string;
+    createdAt: string | Date;
+    updatedAt: string | Date;
+    ipAddress?: string | null;
+    userAgent?: string | null;
+    userId: string;
+}
+
+interface AuthData {
+    user: AuthUser;
+    session: AuthSession;
+}
+
+interface AuthState {
+    authData: AuthData | null;
+    setAuthData: (authData: AuthData | null) => void;
+    clearAuthData: () => void;
+}
+
+export const useAuthStore = create<AuthState>((set) => ({
+    authData: null,
+    setAuthData: (authData) => set({ authData }),
+    clearAuthData: () => set({ authData: null }),
+}));


### PR DESCRIPTION
This pull request introduces a state management solution for synchronizing authentication data across the application. The key changes include integrating a `zustand` store for managing authentication state and updating the `Dashboard` component to use this store for session synchronization and user data display.

### State Management with `zustand`:

* [`src/lib/stores/auth-store.ts`](diffhunk://#diff-8ee36286af3fe84af133b17ef57f1fd974d6f8f9aae2feac644b9a1ad015b9edR1-R40): Added a `zustand` store (`useAuthStore`) to manage authentication state, including user and session data. The store provides methods to set and clear authentication data.

### Updates to the `Dashboard` Component:

* [`src/app/dashboard/page.tsx`](diffhunk://#diff-2c144079a4338bcfeecc2c0f8557d1a11faa7f2ba8ad92283138f05b8806888fL4-R23): Integrated the `useAuthStore` to synchronize session data with the store using `useEffect`. This ensures the authentication state is consistent across the app.
* [`src/app/dashboard/page.tsx`](diffhunk://#diff-2c144079a4338bcfeecc2c0f8557d1a11faa7f2ba8ad92283138f05b8806888fL40-R61): Updated the welcome message to use `authData` from the store, providing a fallback value if user data is unavailable.
* [`src/app/dashboard/page.tsx`](diffhunk://#diff-2c144079a4338bcfeecc2c0f8557d1a11faa7f2ba8ad92283138f05b8806888fL40-R61): Enhanced the sign-out functionality to clear the authentication state from the store upon logout.