### PR TITLE
change theme

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -34,9 +34,9 @@
     --sidebar-accent-foreground: oklch(0.9851 0 0);
     --sidebar-border: oklch(0.2809 0 0);
     --sidebar-ring: oklch(0.8003 0.1821 151.7110);
-    --font-sans: "Outfit", sans-serif;
+    --font-sans: Outfit, sans-serif;
     --font-serif: ui-serif, Georgia, Cambria, "Times New Roman", Times, serif;
-    --font-mono: "JetBrains Mono", monospace;
+    --font-mono: monospace;
     --radius: 0.5rem;
     --shadow-2xs: 0px 1px 3px 0px hsl(0 0% 0% / 0.09);
     --shadow-xs: 0px 1px 3px 0px hsl(0 0% 0% / 0.09);


### PR DESCRIPTION
This pull request makes minor adjustments to the `src/app/globals.css` file by updating font declarations to remove quotes around font names for consistency with CSS standards.

Changes to font declarations:

* [`src/app/globals.css`](diffhunk://#diff-4f206759c961f544a48464ad2ee231adc87e72593d03a0004b68c17771f7a412L37-R39): Removed quotes around `Outfit` in `--font-sans` and replaced `"JetBrains Mono"` with `monospace` in `--font-mono`.